### PR TITLE
Window size change

### DIFF
--- a/src/gui/GUI.java
+++ b/src/gui/GUI.java
@@ -1,3 +1,4 @@
+// @formatter:off
 package gui;
 
 import java.awt.BorderLayout;
@@ -82,6 +83,11 @@ public class GUI {
 
 	public static JLabel seedCount;
 	public static JLabel totalSeedCount;
+	
+	public static JLabel lblMinecraftDirectory;
+	public static JTextField textBoxMinecraftDir;
+	private static JLabel lblMinecraftDirectoryInfo;
+	
 	public static JLabel timeElapsed;
 	public static JTextArea console;
 
@@ -196,7 +202,7 @@ public class GUI {
 		} else {
 			paused = !paused;
 			String text = (paused) ? "Click To Unpause" : "Click to Pause";
-			 
+			
 			if (paused) {
 				pausedTime = System.currentTimeMillis();
 				timer.stop();
@@ -351,6 +357,20 @@ public class GUI {
 		totalSeedCount = new JLabel("Total Rejected Seed Count: 0");
 		totalSeedCount.setBounds(10, 30, 250, 15);
 		panel.add(totalSeedCount);
+		
+		
+		lblMinecraftDirectory = new JLabel("Path to .minecraft directory (optional)");
+		lblMinecraftDirectory.setBounds(10, 60, 400, 15);
+		panel.add(lblMinecraftDirectory);
+
+		lblMinecraftDirectoryInfo = new JLabel("If path is blank/invalid, default .minecraft path will be used");
+		lblMinecraftDirectoryInfo.setBounds(10, 80, 450, 15);
+		panel.add(lblMinecraftDirectoryInfo);
+
+		textBoxMinecraftDir = new JTextField();
+		textBoxMinecraftDir.setBounds(10, 100, 400, 15);
+		panel.add(textBoxMinecraftDir);
+
 		
 		timeElapsed = new JLabel("Time Elapsed: 00:00:00");
 		timeElapsed.setBounds(10, 325, 212, 14);
@@ -1175,7 +1195,7 @@ public class GUI {
 	/**
 	 * Some Biomes come back as null. No idea. The Names match each other so it
 	 * should work (Apparently it works like 1 in 10 times...)
-	 * 
+	 *
 	 * @param biomeCodesCount
 	 * @param biomeCodes
 	 * @return
@@ -1345,7 +1365,7 @@ public class GUI {
 	public static HashMap<String, String> biomeSets(String name){
 		HashMap<String, String> checkedTexts = new HashMap<String, String>();
 		switch(name){
-			case "Desert Set": 
+			case "Desert Set":
 				checkedTexts.put("Desert", "Desert Set");
 				checkedTexts.put("Desert Hills", "Desert Set");
 				checkedTexts.put("Desert M", "Desert Set");
@@ -1377,7 +1397,7 @@ public class GUI {
 				checkedTexts.put("Roofed Forest", "Roofed Forest Set");
 				checkedTexts.put("Roofed Forest M", "Roofed Forest Set");
 				break;
-			case "Swampland Set": 
+			case "Swampland Set":
 				checkedTexts.put("Swampland", "Swampland Set");
 				checkedTexts.put("Swampland M", "Swampland Set");
 				break;
@@ -1423,7 +1443,7 @@ public class GUI {
 				checkedTexts.put("Frozen Ocean", "Frozen Ocean Set");
 				checkedTexts.put("Frozen Deep Ocean", "Frozen Ocean Set");
 				break;
-			default: 
+			default:
 
 				break;
 		}

--- a/src/gui/GUI.java
+++ b/src/gui/GUI.java
@@ -13,22 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTabbedPane;
-import javax.swing.JTextArea;
-import javax.swing.JTextField;
-import javax.swing.ScrollPaneConstants;
-import javax.swing.SwingConstants;
-import javax.swing.Timer;
+import javax.swing.*;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
@@ -46,7 +31,6 @@ import main.Main;
 import main.StructureSearcher;
 import main.StructureSearcher.Type;
 import java.awt.Font;
-import javax.swing.JTextPane;
 
 public class GUI {
 	
@@ -528,6 +512,7 @@ public class GUI {
 										FormSpecs.RELATED_GAP_ROWSPEC,FormSpecs.DEFAULT_ROWSPEC, // Row 70
 										FormSpecs.RELATED_GAP_ROWSPEC,}));
 				
+				
 				JLabel hotBiomesTxt = new JLabel("Hot Biomes");
 				hotBiomesTxt.setHorizontalAlignment(SwingConstants.CENTER);
 				Util.setFontSize(hotBiomesTxt, 18);
@@ -536,19 +521,19 @@ public class GUI {
 				
 				Container _2_4_container = new Container();
 				_2_4_container.add(new JLabel("Desert"));
-				_2_4_container.setLayout(new FlowLayout());
+				_2_4_container.setLayout(new BoxLayout(_2_4_container, BoxLayout.PAGE_AXIS));
 				_2_4_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_4_container, "1, 4");
 				
 				Container _4_4_container = new Container();
 				_4_4_container.add(new JLabel("Desert Hills"));
-				_4_4_container.setLayout(new FlowLayout());
+				_4_4_container.setLayout(new BoxLayout(_4_4_container, BoxLayout.PAGE_AXIS));
 				_4_4_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_4_4_container, "2, 4");
 				
 				Container _6_4_container = new Container();
 				_6_4_container.add(new JLabel("Desert M"));
-				_6_4_container.setLayout(new FlowLayout());
+				_6_4_container.setLayout(new BoxLayout(_6_4_container, BoxLayout.PAGE_AXIS));
 				_6_4_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_6_4_container, "3, 4");
 				
@@ -560,61 +545,61 @@ public class GUI {
 				
 				Container _2_16_container = new Container();
 				_2_16_container.add(new JLabel("Plains"));
-				_2_16_container.setLayout(new FlowLayout());
+				_2_16_container.setLayout(new BoxLayout(_2_16_container, BoxLayout.PAGE_AXIS));
 				_2_16_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_16_container, "1, 16");
 				
 				Container _6_16_container = new Container();
 				_6_16_container.add(new JLabel("Forest"));
-				_6_16_container.setLayout(new FlowLayout());
+				_6_16_container.setLayout(new BoxLayout(_6_16_container, BoxLayout.PAGE_AXIS));
 				_6_16_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_6_16_container, "3, 16");
 				
 				Container _2_18_container = new Container();
 				_2_18_container.add(new JLabel("Forest Hills"));
-				_2_18_container.setLayout(new FlowLayout());
+				_2_18_container.setLayout(new BoxLayout(_2_18_container, BoxLayout.PAGE_AXIS));
 				_2_18_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_18_container, "1, 18");
 				
 				Container _6_22_container = new Container();
 				_6_22_container.add(new JLabel("Swampland"));
-				_6_22_container.setLayout(new FlowLayout());
+				_6_22_container.setLayout(new BoxLayout(_6_22_container, BoxLayout.PAGE_AXIS));
 				_6_22_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_6_22_container, "3, 22");
 				
 				Container _2_24_container = new Container();
 				_2_24_container.add(new JLabel("Swampland M"));
-				_2_24_container.setLayout(new FlowLayout());
+				_2_24_container.setLayout(new BoxLayout(_2_24_container, BoxLayout.PAGE_AXIS));
 				_2_24_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_24_container, "1, 24");
 				
 				Container _4_24_container = new Container();
 				_4_24_container.add(new JLabel("Jungle"));
-				_4_24_container.setLayout(new FlowLayout());
+				_4_24_container.setLayout(new BoxLayout(_4_24_container, BoxLayout.PAGE_AXIS));
 				_4_24_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_4_24_container, "2, 24");
 				
 				Container _6_24_container = new Container();
 				_6_24_container.add(new JLabel("Jungle Hills"));
-				_6_24_container.setLayout(new FlowLayout());
+				_6_24_container.setLayout(new BoxLayout(_6_24_container, BoxLayout.PAGE_AXIS));
 				_6_24_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_6_24_container, "3, 24");
 				
 				Container _2_26_container = new Container();
 				_2_26_container.add(new JLabel("Jungle Edge"));
-				_2_26_container.setLayout(new FlowLayout());
+				_2_26_container.setLayout(new BoxLayout(_2_26_container, BoxLayout.PAGE_AXIS));
 				_2_26_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_26_container, "1, 26");
 				
 				Container _4_26_container = new Container();
 				_4_26_container.add(new JLabel("Jungle M"));
-				_4_26_container.setLayout(new FlowLayout());
+				_4_26_container.setLayout(new BoxLayout(_4_26_container, BoxLayout.PAGE_AXIS));
 				_4_26_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_4_26_container, "2, 26");
 				
 				Container _6_26_container = new Container();
 				_6_26_container.add(new JLabel("Jungle Edge M"));
-				_6_26_container.setLayout(new FlowLayout());
+				_6_26_container.setLayout(new BoxLayout(_6_26_container, BoxLayout.PAGE_AXIS));
 				_6_26_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_6_26_container, "3, 26");
 				
@@ -626,7 +611,7 @@ public class GUI {
 				
 				Container _2_32_container = new Container();
 				_2_32_container.add(new JLabel("Extreme Hills"));
-				_2_32_container.setLayout(new FlowLayout());
+				_2_32_container.setLayout(new BoxLayout(_2_32_container, BoxLayout.PAGE_AXIS));
 				_2_32_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_32_container, "1, 32");
 				
@@ -638,31 +623,31 @@ public class GUI {
 				
 				Container _2_42_container = new Container();
 				_2_42_container.add(new JLabel("Cold Taiga"));
-				_2_42_container.setLayout(new FlowLayout());
+				_2_42_container.setLayout(new BoxLayout(_2_42_container, BoxLayout.PAGE_AXIS));
 				_2_42_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_42_container, "1, 42");
 				
 				Container _4_42_container = new Container();
 				_4_42_container.add(new JLabel("Cold Taiga Hills"));
-				_4_42_container.setLayout(new FlowLayout());
+				_4_42_container.setLayout(new BoxLayout(_4_42_container, BoxLayout.PAGE_AXIS));
 				_4_42_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_4_42_container, "2, 42");
 				
 				Container _6_42_container = new Container();
 				_6_42_container.add(new JLabel("Cold Taiga M"));
-				_6_42_container.setLayout(new FlowLayout());
+				_6_42_container.setLayout(new BoxLayout(_6_42_container, BoxLayout.PAGE_AXIS));
 				_6_42_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_6_42_container, "3, 42");
 				
 				Container _2_44_container = new Container();
 				_2_44_container.add(new JLabel("Ice Plains"));
-				_2_44_container.setLayout(new FlowLayout());
+				_2_44_container.setLayout(new BoxLayout(_2_44_container, BoxLayout.PAGE_AXIS));
 				_2_44_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_44_container, "1, 44");
 				
 				Container _4_44_container = new Container();
 				_4_44_container.add(new JLabel("Ice Mountains"));
-				_4_44_container.setLayout(new FlowLayout());
+				_4_44_container.setLayout(new BoxLayout(_4_44_container, BoxLayout.PAGE_AXIS));
 				_4_44_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_4_44_container, "2, 44");
 				
@@ -674,43 +659,43 @@ public class GUI {
 				
 				Container _2_48_container = new Container();
 				_2_48_container.add(new JLabel("Beach"));
-				_2_48_container.setLayout(new FlowLayout());
+				_2_48_container.setLayout(new BoxLayout(_2_48_container, BoxLayout.PAGE_AXIS));
 				_2_48_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_48_container, "1, 48");
 				
 				Container _2_50_container = new Container();
 				_2_50_container.add(new JLabel("River"));
-				_2_50_container.setLayout(new FlowLayout());
+				_2_50_container.setLayout(new BoxLayout(_2_50_container, BoxLayout.PAGE_AXIS));
 				_2_50_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_50_container, "1, 50");
 				
 				Container _4_50_container = new Container();
 				_4_50_container.add(new JLabel("Ocean"));
-				_4_50_container.setLayout(new FlowLayout());
+				_4_50_container.setLayout(new BoxLayout(_4_50_container, BoxLayout.PAGE_AXIS));
 				_4_50_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_4_50_container, "2, 50");
 				
 				Container _2_52_container = new Container();
 				_2_52_container.add(new JLabel("Frozen River"));
-				_2_52_container.setLayout(new FlowLayout());
+				_2_52_container.setLayout(new BoxLayout(_2_52_container, BoxLayout.PAGE_AXIS));
 				_2_52_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_52_container, "1, 52");
 				
 				Container _4_52_container = new Container();
 				_4_52_container.add(new JLabel("Frozen Ocean"));
-				_4_52_container.setLayout(new FlowLayout());
+				_4_52_container.setLayout(new BoxLayout(_4_52_container, BoxLayout.PAGE_AXIS));
 				_4_52_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_4_52_container, "2, 52");
 				
 				Container _2_54_container = new Container();
 				_2_54_container.add(new JLabel("Mushroom Island"));
-				_2_54_container.setLayout(new FlowLayout());
+				_2_54_container.setLayout(new BoxLayout(_2_54_container, BoxLayout.PAGE_AXIS));
 				_2_54_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_54_container, "1, 54");
 				
 				Container _4_54_container = new Container();
 				_4_54_container.add(new JLabel("Mushroom Island Shore"));
-				_4_54_container.setLayout(new FlowLayout());
+				_4_54_container.setLayout(new BoxLayout(_4_54_container, BoxLayout.PAGE_AXIS));
 				_4_54_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_4_54_container, "2, 54");
 				
@@ -723,92 +708,92 @@ public class GUI {
 
 				Container _1_62_container = new Container();
 				_1_62_container.add(new JLabel("Desert Set"));
-				_1_62_container.setLayout(new FlowLayout());
+				_1_62_container.setLayout(new BoxLayout(_1_62_container, BoxLayout.PAGE_AXIS));
 				_1_62_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_1_62_container, "1, 62");
 
 				Container _2_62_container = new Container();
 				_2_62_container.add(new JLabel("Savanna Set"));
-				_2_62_container.setLayout(new FlowLayout());
+				_2_62_container.setLayout(new BoxLayout(_2_62_container, BoxLayout.PAGE_AXIS));
 				_2_62_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_62_container, "2, 62");
 
 				Container _3_62_container = new Container();
 				_3_62_container.add(new JLabel("Mesa Set"));
-				_3_62_container.setLayout(new FlowLayout());
+				_3_62_container.setLayout(new BoxLayout(_3_62_container, BoxLayout.PAGE_AXIS));
 				_3_62_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_3_62_container, "3, 62");
 
 				Container _1_64_container = new Container();
 				_1_64_container.add(new JLabel("Forest Set"));
-				_1_64_container.setLayout(new FlowLayout());
+				_1_64_container.setLayout(new BoxLayout(_1_64_container, BoxLayout.PAGE_AXIS));
 				_1_64_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_1_64_container, "1, 64");
 
 				Container _2_64_container = new Container();
 				_2_64_container.add(new JLabel("Birch Forest Set"));
-				_2_64_container.setLayout(new FlowLayout());
+				_2_64_container.setLayout(new BoxLayout(_2_64_container, BoxLayout.PAGE_AXIS));
 				_2_64_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_64_container, "2, 64");
 
 				Container _3_64_container = new Container();
 				_3_64_container.add(new JLabel("Roofed Forest Set"));
-				_3_64_container.setLayout(new FlowLayout());
+				_3_64_container.setLayout(new BoxLayout(_3_64_container, BoxLayout.PAGE_AXIS));
 				_3_64_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_3_64_container, "3, 64");
 
 				Container _1_66_container = new Container();
 				_1_66_container.add(new JLabel("Swampland Set"));
-				_1_66_container.setLayout(new FlowLayout());
+				_1_66_container.setLayout(new BoxLayout(_1_66_container, BoxLayout.PAGE_AXIS));
 				_1_66_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_1_66_container, "1, 66");
 
 				
 				Container _2_66_container = new Container();
 				_2_66_container.add(new JLabel("Jungle Set"));
-				_2_66_container.setLayout(new FlowLayout());
+				_2_66_container.setLayout(new BoxLayout(_2_66_container, BoxLayout.PAGE_AXIS));
 				_2_66_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_66_container, "2, 66");
 
 				Container _3_66_container = new Container();
 				_3_66_container.add(new JLabel("Bamboo Jungle Set"));
-				_3_66_container.setLayout(new FlowLayout());
+				_3_66_container.setLayout(new BoxLayout(_3_66_container, BoxLayout.PAGE_AXIS));
 				_3_66_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_3_66_container, "3, 66");
 
 				Container _1_68_container = new Container();
 				_1_68_container.add(new JLabel("Extreme Hills Set"));
-				_1_68_container.setLayout(new FlowLayout());
+				_1_68_container.setLayout(new BoxLayout(_1_68_container, BoxLayout.PAGE_AXIS));
 				_1_68_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_1_68_container, "1, 68");
 				
 				Container _2_68_container = new Container();
 				_2_68_container.add(new JLabel("Taiga Set"));
-				_2_68_container.setLayout(new FlowLayout());
+				_2_68_container.setLayout(new BoxLayout(_2_68_container, BoxLayout.PAGE_AXIS));
 				_2_68_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_68_container, "2, 68");
 
 				Container _3_68_container = new Container();
 				_3_68_container.add(new JLabel("Mega Taiga Set"));
-				_3_68_container.setLayout(new FlowLayout());
+				_3_68_container.setLayout(new BoxLayout(_3_68_container, BoxLayout.PAGE_AXIS));
 				_3_68_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_3_68_container, "3, 68");
 
 				Container _1_70_container = new Container();
 				_1_70_container.add(new JLabel("Cold Taiga Set"));
-				_1_70_container.setLayout(new FlowLayout());
+				_1_70_container.setLayout(new BoxLayout(_1_70_container, BoxLayout.PAGE_AXIS));
 				_1_70_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_1_70_container, "1, 70");
 
 				Container _2_70_container = new Container();
 				_2_70_container.add(new JLabel("Mushroom Island Set"));
-				_2_70_container.setLayout(new FlowLayout());
+				_2_70_container.setLayout(new BoxLayout(_2_70_container, BoxLayout.PAGE_AXIS));
 				_2_70_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_2_70_container, "2, 70");
 
 				Container _3_70_container = new Container();
 				_3_70_container.add(new JLabel("Frozen Ocean Set"));
-				_3_70_container.setLayout(new FlowLayout());
+				_3_70_container.setLayout(new BoxLayout(_3_70_container, BoxLayout.PAGE_AXIS));
 				_3_70_container.add(new JComboBox<String>(include_exclude_txt));
 				biomesPanel.add(_3_70_container, "3, 70");
 		/*
@@ -827,61 +812,61 @@ public class GUI {
 		if (Version.isOrNewerThanVersion(Version.V1_7_10)) {
 			Container _2_6_container = new Container();
 			_2_6_container.add(new JLabel("Savanna"));
-			_2_6_container.setLayout(new FlowLayout());
+			_2_6_container.setLayout(new BoxLayout(_2_6_container, BoxLayout.PAGE_AXIS));
 			_2_6_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_2_6_container, "1, 6");
 			
 			Container _4_6_container = new Container();
 			_4_6_container.add(new JLabel("Savanna Plateau"));
-			_4_6_container.setLayout(new FlowLayout());
+			_4_6_container.setLayout(new BoxLayout(_4_6_container, BoxLayout.PAGE_AXIS));
 			_4_6_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_4_6_container, "2, 6");
 			
 			Container _6_6_container = new Container();
 			_6_6_container.add(new JLabel("Savanna M"));
-			_6_6_container.setLayout(new FlowLayout());
+			_6_6_container.setLayout(new BoxLayout(_6_6_container, BoxLayout.PAGE_AXIS));
 			_6_6_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_6_6_container, "3, 6");
 			
 			Container _2_8_container = new Container();
 			_2_8_container.add(new JLabel("Savanna Plateau M"));
-			_2_8_container.setLayout(new FlowLayout());
+			_2_8_container.setLayout(new BoxLayout(_2_8_container, BoxLayout.PAGE_AXIS));
 			_2_8_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_2_8_container, "1, 8");
 			
 			Container _4_8_container = new Container();
 			_4_8_container.add(new JLabel("Mesa"));
-			_4_8_container.setLayout(new FlowLayout());
+			_4_8_container.setLayout(new BoxLayout(_4_8_container, BoxLayout.PAGE_AXIS));
 			_4_8_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_4_8_container, "2, 8");
 			
 			Container _6_8_container = new Container();
 			_6_8_container.add(new JLabel("Mesa Plateau F"));
-			_6_8_container.setLayout(new FlowLayout());
+			_6_8_container.setLayout(new BoxLayout(_6_8_container, BoxLayout.PAGE_AXIS));
 			_6_8_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_6_8_container, "3, 8");
 			
 			Container _2_10_container = new Container();
 			_2_10_container.add(new JLabel("Mesa Plateau"));
-			_2_10_container.setLayout(new FlowLayout());
+			_2_10_container.setLayout(new BoxLayout(_2_10_container, BoxLayout.PAGE_AXIS));
 			_2_10_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_2_10_container, "1, 10");
 			
 			Container _4_10_container = new Container();
 			_4_10_container.add(new JLabel("Mesa (Bryce)"));
-			_4_10_container.setLayout(new FlowLayout());
+			_4_10_container.setLayout(new BoxLayout(_4_10_container, BoxLayout.PAGE_AXIS));
 			_4_10_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_4_10_container, "2, 10");
 			
 			Container _6_10_container = new Container();
 			_6_10_container.add(new JLabel("Mesa Plateau F M"));
-			_6_10_container.setLayout(new FlowLayout());
+			_6_10_container.setLayout(new BoxLayout(_6_10_container, BoxLayout.PAGE_AXIS));
 			_6_10_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_6_10_container, "3, 10");
 			
 			Container _2_12_container = new Container();
 			_2_12_container.add(new JLabel("Mesa Plateau F M"));
-			_2_12_container.setLayout(new FlowLayout());
+			_2_12_container.setLayout(new BoxLayout(_2_12_container, BoxLayout.PAGE_AXIS));
 			_2_12_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_2_12_container, "1, 12");
 		}
@@ -889,7 +874,7 @@ public class GUI {
 		if (Version.isOrNewerThanVersion(Version.V1_7_10)) {
 			Container _4_16_container = new Container();
 			_4_16_container.add(new JLabel("Sunflower Plains"));
-			_4_16_container.setLayout(new FlowLayout());
+			_4_16_container.setLayout(new BoxLayout(_4_16_container, BoxLayout.PAGE_AXIS));
 			_4_16_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_4_16_container, "2, 16");
 		}
@@ -897,43 +882,43 @@ public class GUI {
 		if (Version.isOrNewerThanVersion(Version.V1_7_10)) {
 			Container _4_18_container = new Container();
 			_4_18_container.add(new JLabel("Flower Forest"));
-			_4_18_container.setLayout(new FlowLayout());
+			_4_18_container.setLayout(new BoxLayout(_4_18_container, BoxLayout.PAGE_AXIS));
 			_4_18_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_4_18_container, "2, 18");
 			
 			Container _6_18_container = new Container();
 			_6_18_container.add(new JLabel("Birch Forest"));
-			_6_18_container.setLayout(new FlowLayout());
+			_6_18_container.setLayout(new BoxLayout(_6_18_container, BoxLayout.PAGE_AXIS));
 			_6_18_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_6_18_container, "3, 18");
 			
 			Container _2_20_container = new Container();
 			_2_20_container.add(new JLabel("Birch Forest Hills"));
-			_2_20_container.setLayout(new FlowLayout());
+			_2_20_container.setLayout(new BoxLayout(_2_20_container, BoxLayout.PAGE_AXIS));
 			_2_20_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_2_20_container, "1, 20");
 			
 			Container _4_20_container = new Container();
 			_4_20_container.add(new JLabel("Birch Forest M"));
-			_4_20_container.setLayout(new FlowLayout());
+			_4_20_container.setLayout(new BoxLayout(_4_20_container, BoxLayout.PAGE_AXIS));
 			_4_20_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_4_20_container, "2, 20");
 			
 			Container _6_20_container = new Container();
 			_6_20_container.add(new JLabel("Birch Forest Hills M"));
-			_6_20_container.setLayout(new FlowLayout());
+			_6_20_container.setLayout(new BoxLayout(_6_20_container, BoxLayout.PAGE_AXIS));
 			_6_20_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_6_20_container, "3, 20");
 			
 			Container _2_22_container = new Container();
 			_2_22_container.add(new JLabel("Roofed Forest"));
-			_2_22_container.setLayout(new FlowLayout());
+			_2_22_container.setLayout(new BoxLayout(_2_22_container, BoxLayout.PAGE_AXIS));
 			_2_22_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_2_22_container, "1, 22");
 			
 			Container _4_22_container = new Container();
 			_4_22_container.add(new JLabel("Roofed Forest M"));
-			_4_22_container.setLayout(new FlowLayout());
+			_4_22_container.setLayout(new BoxLayout(_4_22_container, BoxLayout.PAGE_AXIS));
 			_4_22_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_4_22_container, "2, 22");
 		}
@@ -941,13 +926,13 @@ public class GUI {
 		if (Version.isOrNewerThanVersion(Version.V1_14_3)) {
 			Container _2_28_container = new Container();
 			_2_28_container.add(new JLabel("Bamboo Jungle"));
-			_2_28_container.setLayout(new FlowLayout());
+			_2_28_container.setLayout(new BoxLayout(_2_28_container, BoxLayout.PAGE_AXIS));
 			_2_28_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_2_28_container, "1, 28");
 			
 			Container _4_28_container = new Container();
 			_4_28_container.add(new JLabel("Bamboo Jungle Hills"));
-			_4_28_container.setLayout(new FlowLayout());
+			_4_28_container.setLayout(new BoxLayout(_4_28_container, BoxLayout.PAGE_AXIS));
 			_4_28_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_4_28_container, "2, 28");
 		}
@@ -956,7 +941,7 @@ public class GUI {
 		if (Version.isOrOlderThanVersion(Version.V1_6_4)) {
 			Container _4_32_container = new Container();
 			_4_32_container.add(new JLabel("Extreme Hills Edge"));
-			_4_32_container.setLayout(new FlowLayout());
+			_4_32_container.setLayout(new BoxLayout(_4_32_container, BoxLayout.PAGE_AXIS));
 			_4_32_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_4_32_container, "2, 32");
 		}
@@ -964,61 +949,61 @@ public class GUI {
 		if (Version.isOrNewerThanVersion(Version.V1_7_10)) {
 			Container _6_32_container = new Container();
 			_6_32_container.add(new JLabel("Extreme Hills+"));
-			_6_32_container.setLayout(new FlowLayout());
+			_6_32_container.setLayout(new BoxLayout(_6_32_container, BoxLayout.PAGE_AXIS));
 			_6_32_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_6_32_container, "3, 32");
 			
 			Container _2_34_container = new Container();
 			_2_34_container.add(new JLabel("Extreme Hills M"));
-			_2_34_container.setLayout(new FlowLayout());
+			_2_34_container.setLayout(new BoxLayout(_2_34_container, BoxLayout.PAGE_AXIS));
 			_2_34_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_2_34_container, "1, 34");
 			
 			Container _4_34_container = new Container();
 			_4_34_container.add(new JLabel("Extreme Hills+ M"));
-			_4_34_container.setLayout(new FlowLayout());
+			_4_34_container.setLayout(new BoxLayout(_4_34_container, BoxLayout.PAGE_AXIS));
 			_4_34_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_4_34_container, "2, 34");
 			
 			Container _6_34_container = new Container();
 			_6_34_container.add(new JLabel("Taiga"));
-			_6_34_container.setLayout(new FlowLayout());
+			_6_34_container.setLayout(new BoxLayout(_6_34_container, BoxLayout.PAGE_AXIS));
 			_6_34_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_6_34_container, "3, 34");
 		
 			Container _2_36_container = new Container();
 			_2_36_container.add(new JLabel("Taiga Hills"));
-			_2_36_container.setLayout(new FlowLayout());
+			_2_36_container.setLayout(new BoxLayout(_2_36_container, BoxLayout.PAGE_AXIS));
 			_2_36_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_2_36_container, "1, 36");
 			
 			Container _4_36_container = new Container();
 			_4_36_container.add(new JLabel("Mega Taiga"));
-			_4_36_container.setLayout(new FlowLayout());
+			_4_36_container.setLayout(new BoxLayout(_4_36_container, BoxLayout.PAGE_AXIS));
 			_4_36_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_4_36_container, "2, 36");
 			
 			Container _6_36_container = new Container();
 			_6_36_container.add(new JLabel("Mega Taiga Hills"));
-			_6_36_container.setLayout(new FlowLayout());
+			_6_36_container.setLayout(new BoxLayout(_6_36_container, BoxLayout.PAGE_AXIS));
 			_6_36_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_6_36_container, "3, 36");
 			
 			Container _2_38_container = new Container();
 			_2_38_container.add(new JLabel("Taiga M"));
-			_2_38_container.setLayout(new FlowLayout());
+			_2_38_container.setLayout(new BoxLayout(_2_38_container, BoxLayout.PAGE_AXIS));
 			_2_38_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_2_38_container, "1, 38");
 			
 			Container _4_38_container = new Container();
 			_4_38_container.add(new JLabel("Mega Spruce Taiga"));
-			_4_38_container.setLayout(new FlowLayout());
+			_4_38_container.setLayout(new BoxLayout(_4_38_container, BoxLayout.PAGE_AXIS));
 			_4_38_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_4_38_container, "2, 38");
 			
 			Container _6_38_container = new Container();
 			_6_38_container.add(new JLabel("Mega Spruce Taiga (Hills)"));
-			_6_38_container.setLayout(new FlowLayout());
+			_6_38_container.setLayout(new BoxLayout(_6_38_container, BoxLayout.PAGE_AXIS));
 			_6_38_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_6_38_container, "3, 38");
 		}
@@ -1026,7 +1011,7 @@ public class GUI {
 		if (Version.isOrNewerThanVersion(Version.V1_7_10)) {
 			Container _6_44_container = new Container();
 			_6_44_container.add(new JLabel("Ice Plains Spikes"));
-			_6_44_container.setLayout(new FlowLayout());
+			_6_44_container.setLayout(new BoxLayout(_6_44_container, BoxLayout.PAGE_AXIS));
 			_6_44_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_6_44_container, "3, 44");
 		}
@@ -1034,13 +1019,13 @@ public class GUI {
 		if (Version.isOrNewerThanVersion(Version.V1_7_10)) {
 			Container _4_48_container = new Container();
 			_4_48_container.add(new JLabel("Stone Beach"));
-			_4_48_container.setLayout(new FlowLayout());
+			_4_48_container.setLayout(new BoxLayout(_4_48_container, BoxLayout.PAGE_AXIS));
 			_4_48_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_4_48_container, "2, 48");
 			
 			Container _6_48_container = new Container();
 			_6_48_container.add(new JLabel("Cold Beach"));
-			_6_48_container.setLayout(new FlowLayout());
+			_6_48_container.setLayout(new BoxLayout(_6_48_container, BoxLayout.PAGE_AXIS));
 			_6_48_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_6_48_container, "3, 48");
 		}
@@ -1048,7 +1033,7 @@ public class GUI {
 		if (Version.isOrNewerThanVersion(Version.V1_7_10)) {
 			Container _6_50_container = new Container();
 			_6_50_container.add(new JLabel("Deep Ocean"));
-			_6_50_container.setLayout(new FlowLayout());
+			_6_50_container.setLayout(new BoxLayout(_6_50_container, BoxLayout.PAGE_AXIS));
 			_6_50_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_6_50_container, "3, 50");
 		}
@@ -1056,7 +1041,7 @@ public class GUI {
 		if (Version.isOrNewerThanVersion(Version.V1_13_2)) {
 			Container _6_52_container = new Container();
 			_6_52_container.add(new JLabel("Frozen Deep Ocean"));
-			_6_52_container.setLayout(new FlowLayout());
+			_6_52_container.setLayout(new BoxLayout(_6_52_container, BoxLayout.PAGE_AXIS));
 			_6_52_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_6_52_container, "3, 52");
 		}
@@ -1064,7 +1049,7 @@ public class GUI {
 		if (Version.isOrNewerThanVersion(Version.V1_13_2)) {
 			Container _6_54_container = new Container();
 			_6_54_container.add(new JLabel("Warm Ocean"));
-			_6_54_container.setLayout(new FlowLayout());
+			_6_54_container.setLayout(new BoxLayout(_6_54_container, BoxLayout.PAGE_AXIS));
 			_6_54_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_6_54_container, "3, 54");
 		}
@@ -1072,7 +1057,7 @@ public class GUI {
 		if (Version.isOrNewerThanVersion(Version.V9_99_99)) {
 			Container _2_56_container = new Container();
 			_2_56_container.add(new JLabel("Warm Deep Ocean"));
-			_2_56_container.setLayout(new FlowLayout());
+			_2_56_container.setLayout(new BoxLayout(_2_56_container, BoxLayout.PAGE_AXIS));
 			_2_56_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_2_56_container, "1, 56");
 		}
@@ -1080,25 +1065,25 @@ public class GUI {
 		if (Version.isOrNewerThanVersion(Version.V1_13_2)) {
 			Container _4_56_container = new Container();
 			_4_56_container.add(new JLabel("Lukewarm Ocean"));
-			_4_56_container.setLayout(new FlowLayout());
+			_4_56_container.setLayout(new BoxLayout(_4_56_container, BoxLayout.PAGE_AXIS));
 			_4_56_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_4_56_container, "2, 56");
 			
 			Container _6_56_container = new Container();
 			_6_56_container.add(new JLabel("Lukewarm Deep Ocean"));
-			_6_56_container.setLayout(new FlowLayout());
+			_6_56_container.setLayout(new BoxLayout(_6_56_container, BoxLayout.PAGE_AXIS));
 			_6_56_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_6_56_container, "3, 56");
 			
 			Container _2_58_container = new Container();
 			_2_58_container.add(new JLabel("Cold Ocean"));
-			_2_58_container.setLayout(new FlowLayout());
+			_2_58_container.setLayout(new BoxLayout(_2_58_container, BoxLayout.PAGE_AXIS));
 			_2_58_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_2_58_container, "1, 58");
 			
 			Container _4_58_container = new Container();
 			_4_58_container.add(new JLabel("Cold Deep Ocean"));
-			_4_58_container.setLayout(new FlowLayout());
+			_4_58_container.setLayout(new BoxLayout(_4_58_container, BoxLayout.PAGE_AXIS));
 			_4_58_container.add(new JComboBox<String>(include_exclude_txt));
 			biomesPanel.add(_4_58_container, "2, 58");
 		}

--- a/src/gui/GUI.java
+++ b/src/gui/GUI.java
@@ -68,10 +68,6 @@ public class GUI {
 	public static JLabel seedCount;
 	public static JLabel totalSeedCount;
 	
-	public static JLabel lblMinecraftDirectory;
-	public static JTextField textBoxMinecraftDir;
-	private static JLabel lblMinecraftDirectoryInfo;
-	
 	public static JLabel timeElapsed;
 	public static JTextArea console;
 
@@ -341,20 +337,6 @@ public class GUI {
 		totalSeedCount = new JLabel("Total Rejected Seed Count: 0");
 		totalSeedCount.setBounds(10, 30, 250, 15);
 		panel.add(totalSeedCount);
-		
-		
-		lblMinecraftDirectory = new JLabel("Path to .minecraft directory (optional)");
-		lblMinecraftDirectory.setBounds(10, 60, 400, 15);
-		panel.add(lblMinecraftDirectory);
-
-		lblMinecraftDirectoryInfo = new JLabel("If path is blank/invalid, default .minecraft path will be used");
-		lblMinecraftDirectoryInfo.setBounds(10, 80, 450, 15);
-		panel.add(lblMinecraftDirectoryInfo);
-
-		textBoxMinecraftDir = new JTextField();
-		textBoxMinecraftDir.setBounds(10, 100, 400, 15);
-		panel.add(textBoxMinecraftDir);
-
 		
 		timeElapsed = new JLabel("Time Elapsed: 00:00:00");
 		timeElapsed.setBounds(10, 325, 212, 14);

--- a/src/main/BiomeSearcher.java
+++ b/src/main/BiomeSearcher.java
@@ -1,3 +1,4 @@
+// @formatter:off
 package main;
 
 import java.io.FileNotFoundException;
@@ -67,7 +68,16 @@ public class BiomeSearcher implements Runnable {
 			int searchQuadrantWidth, int searchQuadrantHeight, int maximumMatchingWorldsCount)
 			throws IOException, FormatException, MinecraftInterfaceCreationException {
 		this.mWorldBuilder = WorldBuilder.createSilentPlayerless();
-		final MinecraftInstallation minecraftInstallation = MinecraftInstallation.newLocalMinecraftInstallation();
+		MinecraftInstallation minecraftInstallation;
+
+		String pathToDirectory = GUI.textBoxMinecraftDir.getText();
+		if (pathToDirectory == null ||
+			pathToDirectory.trim().equals(""))
+		{
+			minecraftInstallation = MinecraftInstallation.newLocalMinecraftInstallation();
+		} else {
+			minecraftInstallation = MinecraftInstallation.newLocalMinecraftInstallation(pathToDirectory);
+		}
 		LauncherProfile launcherProfile = null;
 		try{
 			launcherProfile = minecraftInstallation.newLauncherProfile(minecraftVersion);
@@ -104,7 +114,7 @@ public class BiomeSearcher implements Runnable {
 	
 	/**
 	 * Determines whether to accept a world.
-	 * 
+	 *
 	 * @throws MinecraftInterfaceCreationException
 	 * @throws FormatException
 	 * @throws IOException
@@ -145,7 +155,7 @@ public class BiomeSearcher implements Runnable {
 		
 		if (biomes.length == 0 && rejectedBiomes.length == 0 && biomeSets.size() == 0 && rejectedBiomeSets.size() == 0) {
 			Util.console("Creating Selected Biomes from list...");
-			Util.console("Creating Rejected Biomes from list...");	
+			Util.console("Creating Rejected Biomes from list...");
 		}
 		
 		if (biomes.length == 0 && searchBiomes) {
@@ -203,7 +213,7 @@ public class BiomeSearcher implements Runnable {
 					);
 			
 			// Could meet structure requirements, move to next seed.
-			if (!hasRequiredStructures) return false;	
+			if (!hasRequiredStructures) return false;
 		}
 		
 		
@@ -227,10 +237,10 @@ public class BiomeSearcher implements Runnable {
 
 			if (undiscoveredBiomeSets.containsKey(Biome.getByIndex(biomeCodes[biomeCodeIndex]))) {
 				String setValue = undiscoveredBiomeSets.get(Biome.getByIndex(biomeCodes[biomeCodeIndex]));
-				// Get the iterator over the HashMap 
-				undiscoveredBiomeSets.entrySet() 
-				.removeIf( 
-					entry -> (setValue.equals(entry.getValue()))); 
+				// Get the iterator over the HashMap
+				undiscoveredBiomeSets.entrySet()
+				.removeIf(
+					entry -> (setValue.equals(entry.getValue())));
 			}
 
 			if (undiscoveredRejectedBiomeSets.containsKey(Biome.getByIndex(biomeCodes[biomeCodeIndex]))) {
@@ -281,13 +291,13 @@ public class BiomeSearcher implements Runnable {
 		}
 		Util.console(
 				acceptedWorldsCount + ": " + acceptedWorld.getWorldSeed().getLong() + " (rejected "
-						+ rejectedWorldsCount + ")");			
+						+ rejectedWorldsCount + ")");
 	}
 	
 	/**
 	 * Searches for matching worlds, and prints the seed of each matching world
 	 * to the given output stream.
-	 * 
+	 *
 	 * @throws MinecraftInterfaceCreationException
 	 * @throws FormatException
 	 * @throws IOException
@@ -378,7 +388,7 @@ public class BiomeSearcher implements Runnable {
 	 * Execute. new BiomeSearcher(minecraftVersionId, searchCenterKind,
 	 * searchQuadrantWidth, searchQuadrantHeight,
 	 * maximumMatchingWorldsCount).run();
-	 * 
+	 *
 	 * }
 	 */
 }

--- a/src/main/BiomeSearcher.java
+++ b/src/main/BiomeSearcher.java
@@ -68,16 +68,7 @@ public class BiomeSearcher implements Runnable {
 			int searchQuadrantWidth, int searchQuadrantHeight, int maximumMatchingWorldsCount)
 			throws IOException, FormatException, MinecraftInterfaceCreationException {
 		this.mWorldBuilder = WorldBuilder.createSilentPlayerless();
-		MinecraftInstallation minecraftInstallation;
-
-		String pathToDirectory = GUI.textBoxMinecraftDir.getText();
-		if (pathToDirectory == null ||
-			pathToDirectory.trim().equals(""))
-		{
-			minecraftInstallation = MinecraftInstallation.newLocalMinecraftInstallation();
-		} else {
-			minecraftInstallation = MinecraftInstallation.newLocalMinecraftInstallation(pathToDirectory);
-		}
+		final MinecraftInstallation minecraftInstallation = MinecraftInstallation.newLocalMinecraftInstallation();
 		LauncherProfile launcherProfile = null;
 		try{
 			launcherProfile = minecraftInstallation.newLauncherProfile(minecraftVersion);

--- a/src/main/Main.java
+++ b/src/main/Main.java
@@ -1,5 +1,7 @@
+// formatter:off
 package main;
 
+import java.awt.*;
 import java.io.IOException;
 
 import Util.Version;
@@ -8,12 +10,15 @@ import amidst.parsing.FormatException;
 import gui.GUI;
 
 public class Main {
+
+//	public static final int BACK_FRAME_WIDTH = 924;
+//	public static final int BACK_FRAME_HEIGHT = 515;
 	
-	public static final int BACK_FRAME_WIDTH = 924;
-	public static final int BACK_FRAME_HEIGHT = 515;
+	public static final int BACK_FRAME_WIDTH = Math.max(924, (int) (Toolkit.getDefaultToolkit().getScreenSize().width * 0.9));
+	public static final int BACK_FRAME_HEIGHT = Math.max(515, (int) (Toolkit.getDefaultToolkit().getScreenSize().height * 0.8));
 	
-	public static final int CONSOLE_WIDTH = 240;
-	public static final int CONSOLE_HEIGHT = BACK_FRAME_HEIGHT - 100;
+	public static final int CONSOLE_WIDTH = Math.max((int) (BACK_FRAME_WIDTH * 0.3), 240);
+	public static final int CONSOLE_HEIGHT = (int) (BACK_FRAME_HEIGHT * 0.8);
 	
 	public static final int FRAME_WITHOUT_CONSOLE_WIDTH = BACK_FRAME_WIDTH - CONSOLE_WIDTH;
 	public static final int FRAME_WITHOUT_CONSOLE_HEIGHT = BACK_FRAME_HEIGHT - CONSOLE_HEIGHT;


### PR DESCRIPTION
I made some changes to the way the GUI is rendered. Like the person in #12 I couldn't see some of the biome components. I changed it so that the size of the window is proportional to the screen size of the computer, if that is larger than the default size. The console width is calculated as a percentage of the window. Finally, I changed FlowLayout to BoxLayout to align all the biomes into a grid. 

This commit does not contain the code for the .minecraft path selection, so that they can easily be merged separately if at all