### PR TITLE
Optimizations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'com.github.toolbox4minecraft:amidst:v4.4-beta1'
+    implementation 'com.github.toolbox4minecraft:amidst:v4.4'
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 }
 

--- a/src/main/java/sassa/main/BiomeSearcher.java
+++ b/src/main/java/sassa/main/BiomeSearcher.java
@@ -348,6 +348,37 @@ public class BiomeSearcher implements Runnable {
 			return;
 		}
 
+		if (biomes.length > 0 || !biomeSets.isEmpty()) {
+			util.console("Included Biomes:");
+			for (Biome biome : biomes) {
+				util.console("\t" + biome.getName());
+			}
+			for (Biome biome : biomeSets.keySet()) {
+				util.console("\t" + biome.getName());
+			}
+		}
+		if (rejectedBiomes.length > 0 || !rejectedBiomeSets.isEmpty()) {
+			util.console("Excluded Biomes:");
+			for (Biome biome : rejectedBiomes) {
+				util.console("\t" + biome.getName());
+			}
+			for (Biome biome : rejectedBiomeSets.keySet()) {
+				util.console("\t" + biome.getName());
+			}
+		}
+		if (structures.length > 0) {
+			util.console("Included Structures:");
+			for (StructureSearcher.Type structure : structures) {
+				util.console("\t" + structure);
+			}
+		}
+		if (rejectedStructures.length > 0) {
+			util.console("Excluded Structures:");
+			for (StructureSearcher.Type structure : rejectedStructures) {
+				util.console("\t" + structure);
+			}
+		}
+
 		while (acceptedWorldsCount < this.mMaximumMatchingWorldsCount && singleton.getController().isRunning() && this.currentSeedCheck <= this.mMaxSeed && !quitImmediate) {
 			if (!singleton.getController().isPaused()) {
 				World world;

--- a/src/main/java/sassa/main/BiomeSearcher.java
+++ b/src/main/java/sassa/main/BiomeSearcher.java
@@ -187,29 +187,6 @@ public class BiomeSearcher implements Runnable {
 			2 * this.mSearchQuadrantHeight);
 		int biomeCodesCount = biomeCodes.length;
 
-		if (biomes.length == 0 && rejectedBiomes.length == 0 && biomeSets.size() == 0 && rejectedBiomeSets.size() == 0 && structures.length == 0 && rejectedStructures.length == 0) {
-            util.console("Creating search lists...");
-		}
-
-		biomes = guiCollector.getBiomesFromArrayList(Singleton.getInstance().getBiomesGridPane(),"Include");
-		rejectedBiomes = guiCollector.getBiomesFromArrayList(Singleton.getInstance().getBiomesGridPane(),"Exclude");
-		searchBiomes = guiCollector.checkIfBiomesSelected(biomes, searchBiomes);
-        searchRejectedBiomes = guiCollector.checkIfBiomesSelected(rejectedBiomes, searchRejectedBiomes);
-		structures = guiCollector.getStructuresFromArrayList(Singleton.getInstance().getStructureGridPane(), "Include");
-		searchStructures = guiCollector.checkIfStructuresSelected(structures, searchStructures);
-		rejectedStructures = guiCollector.getStructuresFromArrayList(Singleton.getInstance().getStructureGridPane(), "Exclude");
-		searchRejectedStructures = guiCollector.checkIfStructuresSelected(rejectedStructures, searchRejectedStructures);
-		biomeSets = guiCollector.getBiomesSetsFromHashMap(Singleton.getInstance().getBiomeSetsGridPane(), "Include");
-		searchBiomeSets = guiCollector.checkIfBiomeSetsSelected(biomeSets, searchBiomeSets);
-		rejectedBiomeSets = guiCollector.getBiomesSetsFromHashMap(Singleton.getInstance().getBiomeSetsGridPane(), "Include");
-		searchRejectedBiomesSets = guiCollector.checkIfBiomeSetsSelected(rejectedBiomeSets, searchRejectedBiomesSets);
-
-		if (!searchBiomes && !searchRejectedBiomes && !searchBiomeSets && !searchRejectedBiomesSets && !searchStructures && !searchRejectedStructures) {
-			util.console("\nNo biomes are selected or rejected!\nPlease select Biomes!\nSearch has cancelled.\nRecommend you clear console!\n");
-			quitImmediate = true;
-			return false;
-		}
-
 		Set<StructureSearcher.Type> undiscoveredStructures = new HashSet<>(Arrays.asList(structures));
 		for(int i =0; i <= undiscoveredStructures.size(); i++){
 			StructureSearcher.Type struct = StructureSearcher.hasStructures(
@@ -325,11 +302,32 @@ public class BiomeSearcher implements Runnable {
 	 * @throws InterruptedException
 	 */
 	public static int totalRejectedSeedCount = 0;
-	void search() throws InterruptedException,IOException, FormatException, MinecraftInterfaceCreationException {
+	void search() throws InterruptedException, IOException, FormatException, MinecraftInterfaceCreationException, ParseException {
 		int rejectedWorldsCount = 0;
 		int acceptedWorldsCount = 0;
         totalRejectedSeedCount = 0;
         singleton.getSequenceSeed().setText("" + 0);
+
+		util.console("Creating search lists...");
+
+		biomes = guiCollector.getBiomesFromArrayList(Singleton.getInstance().getBiomesGridPane(),"Include");
+		rejectedBiomes = guiCollector.getBiomesFromArrayList(Singleton.getInstance().getBiomesGridPane(),"Exclude");
+		searchBiomes = guiCollector.checkIfBiomesSelected(biomes, searchBiomes);
+		searchRejectedBiomes = guiCollector.checkIfBiomesSelected(rejectedBiomes, searchRejectedBiomes);
+		structures = guiCollector.getStructuresFromArrayList(Singleton.getInstance().getStructureGridPane(), "Include");
+		searchStructures = guiCollector.checkIfStructuresSelected(structures, searchStructures);
+		rejectedStructures = guiCollector.getStructuresFromArrayList(Singleton.getInstance().getStructureGridPane(), "Exclude");
+		searchRejectedStructures = guiCollector.checkIfStructuresSelected(rejectedStructures, searchRejectedStructures);
+		biomeSets = guiCollector.getBiomesSetsFromHashMap(Singleton.getInstance().getBiomeSetsGridPane(), "Include");
+		searchBiomeSets = guiCollector.checkIfBiomeSetsSelected(biomeSets, searchBiomeSets);
+		rejectedBiomeSets = guiCollector.getBiomesSetsFromHashMap(Singleton.getInstance().getBiomeSetsGridPane(), "Include");
+		searchRejectedBiomesSets = guiCollector.checkIfBiomeSetsSelected(rejectedBiomeSets, searchRejectedBiomesSets);
+
+		if (!searchBiomes && !searchRejectedBiomes && !searchBiomeSets && !searchRejectedBiomesSets && !searchStructures && !searchRejectedStructures) {
+			util.console("\nNo biomes/structures are selected or rejected!\nPlease select some before starting!\nSearch has been cancelled.\nRecommend you clear the console!\n");
+			return;
+		}
+
 		while (acceptedWorldsCount < this.mMaximumMatchingWorldsCount && singleton.getController().isRunning() && this.currentSeedCheck < this.mMaxSeed && !quitImmediate) {
 			if (!singleton.getController().isPaused()) {
 				World world;
@@ -389,7 +387,7 @@ public class BiomeSearcher implements Runnable {
 	public void run() {
 		try {
 			search();
-		} catch (InterruptedException | IOException | FormatException | MinecraftInterfaceCreationException e) {
+		} catch (ParseException | InterruptedException | IOException | FormatException | MinecraftInterfaceCreationException e) {
 			e.printStackTrace();
 		}
 

--- a/src/main/java/sassa/main/BiomeSearcher.java
+++ b/src/main/java/sassa/main/BiomeSearcher.java
@@ -183,7 +183,6 @@ public class BiomeSearcher implements Runnable {
 		Set<StructureSearcher.Type> undiscoveredStructures = new HashSet<>(Arrays.asList(structures));
 		// Only search if list not empty
 		if (!undiscoveredStructures.isEmpty()) {
-			System.out.println("Looking for structures..");
 			List<StructureSearcher.Type> foundStructures = StructureSearcher.hasStructures(
 					undiscoveredStructures,
 					world,
@@ -195,7 +194,7 @@ public class BiomeSearcher implements Runnable {
 				undiscoveredStructures.remove(struct);
 			}
 
-			// Some structures not found, seed is rejected
+			// Check if any included structures have not been found, if so seed is rejected
 			if (!undiscoveredStructures.isEmpty()) {
 				return false;
 			}
@@ -212,7 +211,7 @@ public class BiomeSearcher implements Runnable {
 					this.mSearchQuadrantHeight * 2,
 					this.mSearchQuadrantWidth * 2);
 			for (StructureSearcher.Type struct : foundRejectedStructures) {
-				// Found structure we want excluded, seed is rejected
+				// Check if any excluded structures have been found, if so seed is rejected
 				if(undiscoveredRejectedStructures.contains(struct)){
 					return false;
 				}
@@ -225,7 +224,6 @@ public class BiomeSearcher implements Runnable {
 		HashMap<Biome, String> undiscoveredRejectedBiomeSets = new HashMap<>(rejectedBiomeSets);
 		// Only search if lists are not empty
 		if (!undiscoveredBiomes.isEmpty() || !undiscoveredRejectedBiomes.isEmpty() || !undiscoveredBiomeSets.isEmpty() || !undiscoveredRejectedBiomeSets.isEmpty()) {
-			System.out.println("Looking for biomes..");
 			int[] biomeCodes = getBiomeCodes(
 					searchCenterX - this.mSearchQuadrantWidth,
 					searchCenterY - this.mSearchQuadrantHeight,

--- a/src/main/java/sassa/main/BiomeSearcher.java
+++ b/src/main/java/sassa/main/BiomeSearcher.java
@@ -340,7 +340,7 @@ public class BiomeSearcher implements Runnable {
 		searchRejectedStructures = guiCollector.checkIfStructuresSelected(rejectedStructures, searchRejectedStructures);
 		biomeSets = guiCollector.getBiomesSetsFromHashMap(Singleton.getInstance().getBiomeSetsGridPane(), "Include");
 		searchBiomeSets = guiCollector.checkIfBiomeSetsSelected(biomeSets, searchBiomeSets);
-		rejectedBiomeSets = guiCollector.getBiomesSetsFromHashMap(Singleton.getInstance().getBiomeSetsGridPane(), "Include");
+		rejectedBiomeSets = guiCollector.getBiomesSetsFromHashMap(Singleton.getInstance().getBiomeSetsGridPane(), "Exclude");
 		searchRejectedBiomesSets = guiCollector.checkIfBiomeSetsSelected(rejectedBiomeSets, searchRejectedBiomesSets);
 
 		if (!searchBiomes && !searchRejectedBiomes && !searchBiomeSets && !searchRejectedBiomesSets && !searchStructures && !searchRejectedStructures) {

--- a/src/main/java/sassa/main/StructureSearcher.java
+++ b/src/main/java/sassa/main/StructureSearcher.java
@@ -156,49 +156,49 @@ public class StructureSearcher {
 						world,
 						coords);
 				if (mineshafts.size() >= 1 && (nwCornerX + distX) > mineshafts.get(0).getCoordinates().getX() && (nwCornerY + distY) > mineshafts.get(0).getCoordinates().getY()) {
-                    foundStructures.add(type);
+					foundStructures.add(type);
 				}
 			} else if (type.equals(Type.OCEAN_RUINS)) {
 				List<WorldIcon> ocean_ruins = StructureSearcher.findOceanRuins(
 						world,
 						coords);
 				if (ocean_ruins.size() >= 1 && (nwCornerX + distX) > ocean_ruins.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_ruins.get(0).getCoordinates().getY()) {
-                    foundStructures.add(type);
+					foundStructures.add(type);
 				}
 			} else if (type.equals(Type.OCEAN_FEATURES)) {
 				List<WorldIcon> ocean_features = StructureSearcher.findOceanFeatures(
 						world,
 						coords);
 				if (ocean_features.size() >= 1 && (nwCornerX + distX) > ocean_features.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_features.get(0).getCoordinates().getY()) {
-                    foundStructures.add(type);
+					foundStructures.add(type);
 				}
 			} else if (type.equals(Type.OCEAN_MONUMENT)) {
 				List<WorldIcon> ocean_monuments = StructureSearcher.findOceanMounments(
 						world,
 						coords);
 				if (ocean_monuments.size() >= 1 && (nwCornerX + distX) > ocean_monuments.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_monuments.get(0).getCoordinates().getY()) {
-                    foundStructures.add(type);
+					foundStructures.add(type);
 				}
 			} else if (type.equals(Type.SHIPWRECK)) {
 				List<WorldIcon> shipwreck = StructureSearcher.findShipwreck(
 						world,
 						coords);
 				if (shipwreck.size() >= 1 && (nwCornerX + distX) > shipwreck.get(0).getCoordinates().getX() && (nwCornerY + distY) > shipwreck.get(0).getCoordinates().getY()) {
-                    foundStructures.add(type);
+					foundStructures.add(type);
 				}
 			} else if (type.equals(Type.BURIED_TREASURE)) {
 				List<WorldIcon> buriedTreasure = StructureSearcher.findBuriedTreasure(
 						world,
 						coords);
 				if (buriedTreasure.size() >= 1 && (nwCornerX + distX) > buriedTreasure.get(0).getCoordinates().getX() && (nwCornerY + distY) > buriedTreasure.get(0).getCoordinates().getY()) {
-                    foundStructures.add(type);
+					foundStructures.add(type);
 				}
 			} else if (type.equals(Type.MANSION)) {
 				List<WorldIcon> mansion = StructureSearcher.findMansion(
 						world,
 						coords);
 				if (mansion.size() >= 1 && (nwCornerX + distX) > mansion.get(0).getCoordinates().getX() && (nwCornerY + distY) > mansion.get(0).getCoordinates().getY()) {
-                    foundStructures.add(type);
+					foundStructures.add(type);
 				}
 
 			} else if (type.equals(Type.STRONGHOLD)) {
@@ -206,49 +206,49 @@ public class StructureSearcher {
 						world,
 						coords);
 				if (stronghold.size() >= 1 && (nwCornerX + distX) > stronghold.get(0).getCoordinates().getX() && (nwCornerY + distY) > stronghold.get(0).getCoordinates().getY()) {
-                    foundStructures.add(type);
+					foundStructures.add(type);
 				}
 			} else if (type.equals(Type.VILLAGE)) {
 				List<WorldIcon> village = StructureSearcher.findVillage(
 						world,
 						coords);
 				if (village.size() >= 1 && (nwCornerX + distX) > village.get(0).getCoordinates().getX() && (nwCornerY + distY) > village.get(0).getCoordinates().getY()) {
-                    foundStructures.add(type);;
+					foundStructures.add(type);;
 				}
 			} else if (type.equals(Type.PILLAGER_OUTPOST)) {
 				List<WorldIcon> pillagerOutpost = StructureSearcher.findPillagerOutpost(
 						world,
 						coords);
 				if (pillagerOutpost.size() >= 1 && (nwCornerX + distX) > pillagerOutpost.get(0).getCoordinates().getX() && (nwCornerY + distY) > pillagerOutpost.get(0).getCoordinates().getY()) {
-                    foundStructures.add(type);
+					foundStructures.add(type);
 				}
 			} else if (type.equals(Type.DESERT_TEMPLE)) {
 				List<WorldIcon> deserttemple = StructureSearcher.findDesertTemple(
 						world,
 						coords);
 				if (deserttemple.size() >= 1 && (nwCornerX + distX) > deserttemple.get(0).getCoordinates().getX() && (nwCornerY + distY) > deserttemple.get(0).getCoordinates().getY()) {
-                    foundStructures.add(type);
+					foundStructures.add(type);
 				}
 			} else if (type.equals(Type.JUNGLE_TEMPLE)) {
 				List<WorldIcon> jungleTemple = StructureSearcher.findJungleTemple(
 						world,
 						coords);
 				if (jungleTemple.size() >= 1 && (nwCornerX + distX) > jungleTemple.get(0).getCoordinates().getX() && (nwCornerY + distY) > jungleTemple.get(0).getCoordinates().getY()) {
-                    foundStructures.add(type);
+					foundStructures.add(type);
 				}
 			} else if (type.equals(Type.WITCH_HUT)) {
 				List<WorldIcon> witchhut = StructureSearcher.findWitchHut(
 						world,
 						coords);
 				if (witchhut.size() >= 1 && (nwCornerX + distX) > witchhut.get(0).getCoordinates().getX() && (nwCornerY + distY) > witchhut.get(0).getCoordinates().getY()) {
-                    foundStructures.add(type);
+					foundStructures.add(type);
 				}
 			} else if (type.equals(Type.IGLOO)) {
 				List<WorldIcon> igloo = StructureSearcher.findIgloo(
 						world,
 						coords);
 				if (igloo.size() >= 1 && (nwCornerX + distX) > igloo.get(0).getCoordinates().getX() && (nwCornerY + distY) > igloo.get(0).getCoordinates().getY()) {
-                    foundStructures.add(type);
+					foundStructures.add(type);
 				}
 			}
 		}

--- a/src/main/java/sassa/main/StructureSearcher.java
+++ b/src/main/java/sassa/main/StructureSearcher.java
@@ -147,57 +147,58 @@ public class StructureSearcher {
 		return CoordinatesInWorld.from(nwCornerX, nwCornerY);
 	}
 
-	public static Type hasStructures(Set<Type> structures, World world, long nwCornerX, long nwCornerY, int distX, int distY) {
+	public static List<Type> hasStructures(Set<Type> structures, World world, long nwCornerX, long nwCornerY, int distX, int distY) {
 		CoordinatesInWorld coords = coords(nwCornerX, nwCornerY);
+        List<Type> foundStructures = new ArrayList();;
 		for (Type type : structures) {
 			if (type.equals(Type.MINESHAFT)) {
 				List<WorldIcon> mineshafts = StructureSearcher.findMineshafts(
 						world,
 						coords);
 				if (mineshafts.size() >= 1 && (nwCornerX + distX) > mineshafts.get(0).getCoordinates().getX() && (nwCornerY + distY) > mineshafts.get(0).getCoordinates().getY()) {
-					return type;
+                    foundStructures.add(type);
 				}
 			} else if (type.equals(Type.OCEAN_RUINS)) {
 				List<WorldIcon> ocean_ruins = StructureSearcher.findOceanRuins(
 						world,
 						coords);
 				if (ocean_ruins.size() >= 1 && (nwCornerX + distX) > ocean_ruins.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_ruins.get(0).getCoordinates().getY()) {
-					return type;
+                    foundStructures.add(type);
 				}
 			} else if (type.equals(Type.OCEAN_FEATURES)) {
 				List<WorldIcon> ocean_features = StructureSearcher.findOceanFeatures(
 						world,
 						coords);
 				if (ocean_features.size() >= 1 && (nwCornerX + distX) > ocean_features.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_features.get(0).getCoordinates().getY()) {
-					return type;
+                    foundStructures.add(type);
 				}
 			} else if (type.equals(Type.OCEAN_MONUMENT)) {
 				List<WorldIcon> ocean_monuments = StructureSearcher.findOceanMounments(
 						world,
 						coords);
 				if (ocean_monuments.size() >= 1 && (nwCornerX + distX) > ocean_monuments.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_monuments.get(0).getCoordinates().getY()) {
-					return type;
+                    foundStructures.add(type);
 				}
 			} else if (type.equals(Type.SHIPWRECK)) {
 				List<WorldIcon> shipwreck = StructureSearcher.findShipwreck(
 						world,
 						coords);
 				if (shipwreck.size() >= 1 && (nwCornerX + distX) > shipwreck.get(0).getCoordinates().getX() && (nwCornerY + distY) > shipwreck.get(0).getCoordinates().getY()) {
-					return type;
+                    foundStructures.add(type);
 				}
 			} else if (type.equals(Type.BURIED_TREASURE)) {
 				List<WorldIcon> buriedTreasure = StructureSearcher.findBuriedTreasure(
 						world,
 						coords);
 				if (buriedTreasure.size() >= 1 && (nwCornerX + distX) > buriedTreasure.get(0).getCoordinates().getX() && (nwCornerY + distY) > buriedTreasure.get(0).getCoordinates().getY()) {
-					return type;
+                    foundStructures.add(type);
 				}
 			} else if (type.equals(Type.MANSION)) {
 				List<WorldIcon> mansion = StructureSearcher.findMansion(
 						world,
 						coords);
 				if (mansion.size() >= 1 && (nwCornerX + distX) > mansion.get(0).getCoordinates().getX() && (nwCornerY + distY) > mansion.get(0).getCoordinates().getY()) {
-					return type;
+                    foundStructures.add(type);
 				}
 
 			} else if (type.equals(Type.STRONGHOLD)) {
@@ -205,54 +206,54 @@ public class StructureSearcher {
 						world,
 						coords);
 				if (stronghold.size() >= 1 && (nwCornerX + distX) > stronghold.get(0).getCoordinates().getX() && (nwCornerY + distY) > stronghold.get(0).getCoordinates().getY()) {
-					return type;
+                    foundStructures.add(type);
 				}
 			} else if (type.equals(Type.VILLAGE)) {
 				List<WorldIcon> village = StructureSearcher.findVillage(
 						world,
 						coords);
 				if (village.size() >= 1 && (nwCornerX + distX) > village.get(0).getCoordinates().getX() && (nwCornerY + distY) > village.get(0).getCoordinates().getY()) {
-					return type;
+                    foundStructures.add(type);;
 				}
 			} else if (type.equals(Type.PILLAGER_OUTPOST)) {
 				List<WorldIcon> pillagerOutpost = StructureSearcher.findPillagerOutpost(
 						world,
 						coords);
 				if (pillagerOutpost.size() >= 1 && (nwCornerX + distX) > pillagerOutpost.get(0).getCoordinates().getX() && (nwCornerY + distY) > pillagerOutpost.get(0).getCoordinates().getY()) {
-					return type;
+                    foundStructures.add(type);
 				}
 			} else if (type.equals(Type.DESERT_TEMPLE)) {
 				List<WorldIcon> deserttemple = StructureSearcher.findDesertTemple(
 						world,
 						coords);
 				if (deserttemple.size() >= 1 && (nwCornerX + distX) > deserttemple.get(0).getCoordinates().getX() && (nwCornerY + distY) > deserttemple.get(0).getCoordinates().getY()) {
-					return type;
+                    foundStructures.add(type);
 				}
 			} else if (type.equals(Type.JUNGLE_TEMPLE)) {
 				List<WorldIcon> jungleTemple = StructureSearcher.findJungleTemple(
 						world,
 						coords);
 				if (jungleTemple.size() >= 1 && (nwCornerX + distX) > jungleTemple.get(0).getCoordinates().getX() && (nwCornerY + distY) > jungleTemple.get(0).getCoordinates().getY()) {
-					return type;
+                    foundStructures.add(type);
 				}
 			} else if (type.equals(Type.WITCH_HUT)) {
 				List<WorldIcon> witchhut = StructureSearcher.findWitchHut(
 						world,
 						coords);
 				if (witchhut.size() >= 1 && (nwCornerX + distX) > witchhut.get(0).getCoordinates().getX() && (nwCornerY + distY) > witchhut.get(0).getCoordinates().getY()) {
-					return type;
+                    foundStructures.add(type);
 				}
 			} else if (type.equals(Type.IGLOO)) {
 				List<WorldIcon> igloo = StructureSearcher.findIgloo(
 						world,
 						coords);
 				if (igloo.size() >= 1 && (nwCornerX + distX) > igloo.get(0).getCoordinates().getX() && (nwCornerY + distY) > igloo.get(0).getCoordinates().getY()) {
-					return type;
+                    foundStructures.add(type);
 				}
 			}
 		}
 
-		return null;
+		return foundStructures;
 	}
 	
 }


### PR DESCRIPTION
- Don't reload list of included/excluded biomes/structures for every seed checked, only do it when the search is started.
- Optimize structure search
  - Don't search for the same structures multiple times, only check for each structure once.
- Prioritize structures over biomes (structures are quicker than biomes to find)
- Only search if we have that type included/excluded
- Optimize biome search
- Fix excluding biome sets
- Display list of items being included/excluded upon search start
- Update amidst to `v4.4`

closes #7 maybe _(couldn't reproduce, was able to find biomes excluding ocean)_