### PR TITLE
Fix finding structures in areas larger than 512x512 (256 distance from spawn)

### DIFF
--- a/src/main/java/sassa/main/BiomeSearcher.java
+++ b/src/main/java/sassa/main/BiomeSearcher.java
@@ -192,7 +192,7 @@ public class BiomeSearcher implements Runnable {
 		Set<StructureSearcher.Type> undiscoveredStructures = new HashSet<>(Arrays.asList(structures));
 		// Only search if list not empty
 		if (!undiscoveredStructures.isEmpty()) {
-			List<StructureSearcher.Type> foundStructures = StructureSearcher.hasStructures(
+			Set<StructureSearcher.Type> foundStructures = StructureSearcher.hasStructures(
 					undiscoveredStructures,
 					world,
 					searchCenterX - this.mSearchQuadrantHeight,
@@ -212,7 +212,7 @@ public class BiomeSearcher implements Runnable {
 		Set<StructureSearcher.Type> undiscoveredRejectedStructures = new HashSet<>(Arrays.asList(rejectedStructures));
 		// Only search if list not empty
 		if (!undiscoveredRejectedStructures.isEmpty()) {
-			List<StructureSearcher.Type> foundRejectedStructures = StructureSearcher.hasStructures(
+			Set<StructureSearcher.Type> foundRejectedStructures = StructureSearcher.hasStructures(
 					undiscoveredRejectedStructures,
 					world,
 					searchCenterX - this.mSearchQuadrantHeight,

--- a/src/main/java/sassa/main/StructureSearcher.java
+++ b/src/main/java/sassa/main/StructureSearcher.java
@@ -162,7 +162,6 @@ public class StructureSearcher {
 								coords);
 						if (mineshafts.size() >= 1 && (nwCornerX + distX) > mineshafts.get(0).getCoordinates().getX() && (nwCornerY + distY) > mineshafts.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
-							structures.remove(type);
 						}
 					} else if (type.equals(Type.OCEAN_RUINS)) {
 						List<WorldIcon> ocean_ruins = StructureSearcher.findOceanRuins(
@@ -170,7 +169,6 @@ public class StructureSearcher {
 								coords);
 						if (ocean_ruins.size() >= 1 && (nwCornerX + distX) > ocean_ruins.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_ruins.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
-							structures.remove(type);
 						}
 					} else if (type.equals(Type.OCEAN_FEATURES)) {
 						List<WorldIcon> ocean_features = StructureSearcher.findOceanFeatures(
@@ -178,7 +176,6 @@ public class StructureSearcher {
 								coords);
 						if (ocean_features.size() >= 1 && (nwCornerX + distX) > ocean_features.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_features.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
-							structures.remove(type);
 						}
 					} else if (type.equals(Type.OCEAN_MONUMENT)) {
 						List<WorldIcon> ocean_monuments = StructureSearcher.findOceanMounments(
@@ -186,7 +183,6 @@ public class StructureSearcher {
 								coords);
 						if (ocean_monuments.size() >= 1 && (nwCornerX + distX) > ocean_monuments.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_monuments.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
-							structures.remove(type);
 						}
 					} else if (type.equals(Type.SHIPWRECK)) {
 						List<WorldIcon> shipwreck = StructureSearcher.findShipwreck(
@@ -194,7 +190,6 @@ public class StructureSearcher {
 								coords);
 						if (shipwreck.size() >= 1 && (nwCornerX + distX) > shipwreck.get(0).getCoordinates().getX() && (nwCornerY + distY) > shipwreck.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
-							structures.remove(type);
 						}
 					} else if (type.equals(Type.BURIED_TREASURE)) {
 						List<WorldIcon> buriedTreasure = StructureSearcher.findBuriedTreasure(
@@ -202,7 +197,6 @@ public class StructureSearcher {
 								coords);
 						if (buriedTreasure.size() >= 1 && (nwCornerX + distX) > buriedTreasure.get(0).getCoordinates().getX() && (nwCornerY + distY) > buriedTreasure.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
-							structures.remove(type);
 						}
 					} else if (type.equals(Type.MANSION)) {
 						List<WorldIcon> mansion = StructureSearcher.findMansion(
@@ -210,7 +204,6 @@ public class StructureSearcher {
 								coords);
 						if (mansion.size() >= 1 && (nwCornerX + distX) > mansion.get(0).getCoordinates().getX() && (nwCornerY + distY) > mansion.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
-							structures.remove(type);
 						}
 					} else if (type.equals(Type.STRONGHOLD)) {
 						List<WorldIcon> stronghold = StructureSearcher.findStronghold(
@@ -218,7 +211,6 @@ public class StructureSearcher {
 								coords);
 						if (stronghold.size() >= 1 && (nwCornerX + distX) > stronghold.get(0).getCoordinates().getX() && (nwCornerY + distY) > stronghold.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
-							structures.remove(type);
 						}
 					} else if (type.equals(Type.VILLAGE)) {
 						List<WorldIcon> village = StructureSearcher.findVillage(
@@ -226,7 +218,6 @@ public class StructureSearcher {
 								coords);
 						if (village.size() >= 1 && (nwCornerX + distX) > village.get(0).getCoordinates().getX() && (nwCornerY + distY) > village.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);;
-							structures.remove(type);
 						}
 					} else if (type.equals(Type.PILLAGER_OUTPOST)) {
 						List<WorldIcon> pillagerOutpost = StructureSearcher.findPillagerOutpost(
@@ -234,7 +225,6 @@ public class StructureSearcher {
 								coords);
 						if (pillagerOutpost.size() >= 1 && (nwCornerX + distX) > pillagerOutpost.get(0).getCoordinates().getX() && (nwCornerY + distY) > pillagerOutpost.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
-							structures.remove(type);
 						}
 					} else if (type.equals(Type.DESERT_TEMPLE)) {
 						List<WorldIcon> deserttemple = StructureSearcher.findDesertTemple(
@@ -242,7 +232,6 @@ public class StructureSearcher {
 								coords);
 						if (deserttemple.size() >= 1 && (nwCornerX + distX) > deserttemple.get(0).getCoordinates().getX() && (nwCornerY + distY) > deserttemple.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
-							structures.remove(type);
 						}
 					} else if (type.equals(Type.JUNGLE_TEMPLE)) {
 						List<WorldIcon> jungleTemple = StructureSearcher.findJungleTemple(
@@ -250,7 +239,6 @@ public class StructureSearcher {
 								coords);
 						if (jungleTemple.size() >= 1 && (nwCornerX + distX) > jungleTemple.get(0).getCoordinates().getX() && (nwCornerY + distY) > jungleTemple.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
-							structures.remove(type);
 						}
 					} else if (type.equals(Type.WITCH_HUT)) {
 						List<WorldIcon> witchhut = StructureSearcher.findWitchHut(
@@ -258,7 +246,6 @@ public class StructureSearcher {
 								coords);
 						if (witchhut.size() >= 1 && (nwCornerX + distX) > witchhut.get(0).getCoordinates().getX() && (nwCornerY + distY) > witchhut.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
-							structures.remove(type);
 						}
 					} else if (type.equals(Type.IGLOO)) {
 						List<WorldIcon> igloo = StructureSearcher.findIgloo(
@@ -266,10 +253,11 @@ public class StructureSearcher {
 								coords);
 						if (igloo.size() >= 1 && (nwCornerX + distX) > igloo.get(0).getCoordinates().getX() && (nwCornerY + distY) > igloo.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
-							structures.remove(type);
 						}
 					}
 				}
+				// Remove any structures we have already found, reduce unneeded lookups
+				structures.removeAll(foundStructures);
 				multiplierY++;
 			}
 			multiplierY=0;

--- a/src/main/java/sassa/main/StructureSearcher.java
+++ b/src/main/java/sassa/main/StructureSearcher.java
@@ -5,6 +5,7 @@ import amidst.mojangapi.world.coordinates.CoordinatesInWorld;
 import amidst.mojangapi.world.icon.WorldIcon;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -147,8 +148,8 @@ public class StructureSearcher {
 		return CoordinatesInWorld.from(nwCornerX, nwCornerY);
 	}
 
-	public static List<Type> hasStructures(Set<Type> structures, World world, long nwCornerX, long nwCornerY, int distX, int distY) {
-        List<Type> foundStructures = new ArrayList();
+	public static Set<Type> hasStructures(Set<Type> structures, World world, long nwCornerX, long nwCornerY, int distX, int distY) {
+		Set<Type> foundStructures = new HashSet<>();
         int multiplierX = 0;
         int multiplierY = 0;
 		while ((nwCornerX + (multiplierX * 512)) < (nwCornerX + distX) && !structures.isEmpty()) {

--- a/src/main/java/sassa/main/StructureSearcher.java
+++ b/src/main/java/sassa/main/StructureSearcher.java
@@ -155,7 +155,6 @@ public class StructureSearcher {
 		while ((nwCornerX + (multiplierX * 512)) < (nwCornerX + distX) && !structures.isEmpty()) {
 			while ((nwCornerY + (multiplierY * 512)) < (nwCornerY + distY) && !structures.isEmpty()) {
 				CoordinatesInWorld coords = coords(nwCornerX + (multiplierX * 512), nwCornerY + (multiplierY * 512));
-				System.out.println("Searching coords: " + coords);
 				for (Type type : structures) {
 					if (type.equals(Type.MINESHAFT)) {
 						List<WorldIcon> mineshafts = StructureSearcher.findMineshafts(

--- a/src/main/java/sassa/main/StructureSearcher.java
+++ b/src/main/java/sassa/main/StructureSearcher.java
@@ -25,6 +25,7 @@ public class StructureSearcher {
 		List<WorldIcon> villageFeatures = findVillageFeatures(world, coords);
 		List<WorldIcon> pillager_outpost = new ArrayList<WorldIcon>();
 		for (WorldIcon feature : villageFeatures) {
+            System.out.println("Found feature: " + feature.getName() + " - " + feature.getCoordinates());
 			if (feature.getName().toUpperCase().equals("PILLAGER OUTPOST")) {
 				pillager_outpost.add(feature);
 			}
@@ -151,8 +152,8 @@ public class StructureSearcher {
         List<Type> foundStructures = new ArrayList();
         int multiplierX = 0;
         int multiplierY = 0;
-		while ((nwCornerX + (multiplierX * 512)) < (nwCornerX + distX)) {
-			while ((nwCornerY + (multiplierY * 512)) < (nwCornerY + distY)) {
+		while ((nwCornerX + (multiplierX * 512)) < (nwCornerX + distX) && !structures.isEmpty()) {
+			while ((nwCornerY + (multiplierY * 512)) < (nwCornerY + distY) && !structures.isEmpty()) {
 				CoordinatesInWorld coords = coords(nwCornerX + (multiplierX * 512), nwCornerY + (multiplierY * 512));
 				System.out.println("Searching coords: " + coords);
 				for (Type type : structures) {
@@ -162,6 +163,7 @@ public class StructureSearcher {
 								coords);
 						if (mineshafts.size() >= 1 && (nwCornerX + distX) > mineshafts.get(0).getCoordinates().getX() && (nwCornerY + distY) > mineshafts.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
+							structures.remove(type);
 						}
 					} else if (type.equals(Type.OCEAN_RUINS)) {
 						List<WorldIcon> ocean_ruins = StructureSearcher.findOceanRuins(
@@ -169,6 +171,7 @@ public class StructureSearcher {
 								coords);
 						if (ocean_ruins.size() >= 1 && (nwCornerX + distX) > ocean_ruins.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_ruins.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
+							structures.remove(type);
 						}
 					} else if (type.equals(Type.OCEAN_FEATURES)) {
 						List<WorldIcon> ocean_features = StructureSearcher.findOceanFeatures(
@@ -176,6 +179,7 @@ public class StructureSearcher {
 								coords);
 						if (ocean_features.size() >= 1 && (nwCornerX + distX) > ocean_features.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_features.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
+							structures.remove(type);
 						}
 					} else if (type.equals(Type.OCEAN_MONUMENT)) {
 						List<WorldIcon> ocean_monuments = StructureSearcher.findOceanMounments(
@@ -183,6 +187,7 @@ public class StructureSearcher {
 								coords);
 						if (ocean_monuments.size() >= 1 && (nwCornerX + distX) > ocean_monuments.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_monuments.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
+							structures.remove(type);
 						}
 					} else if (type.equals(Type.SHIPWRECK)) {
 						List<WorldIcon> shipwreck = StructureSearcher.findShipwreck(
@@ -190,6 +195,7 @@ public class StructureSearcher {
 								coords);
 						if (shipwreck.size() >= 1 && (nwCornerX + distX) > shipwreck.get(0).getCoordinates().getX() && (nwCornerY + distY) > shipwreck.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
+							structures.remove(type);
 						}
 					} else if (type.equals(Type.BURIED_TREASURE)) {
 						List<WorldIcon> buriedTreasure = StructureSearcher.findBuriedTreasure(
@@ -197,6 +203,7 @@ public class StructureSearcher {
 								coords);
 						if (buriedTreasure.size() >= 1 && (nwCornerX + distX) > buriedTreasure.get(0).getCoordinates().getX() && (nwCornerY + distY) > buriedTreasure.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
+							structures.remove(type);
 						}
 					} else if (type.equals(Type.MANSION)) {
 						List<WorldIcon> mansion = StructureSearcher.findMansion(
@@ -204,6 +211,7 @@ public class StructureSearcher {
 								coords);
 						if (mansion.size() >= 1 && (nwCornerX + distX) > mansion.get(0).getCoordinates().getX() && (nwCornerY + distY) > mansion.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
+							structures.remove(type);
 						}
 					} else if (type.equals(Type.STRONGHOLD)) {
 						List<WorldIcon> stronghold = StructureSearcher.findStronghold(
@@ -211,6 +219,7 @@ public class StructureSearcher {
 								coords);
 						if (stronghold.size() >= 1 && (nwCornerX + distX) > stronghold.get(0).getCoordinates().getX() && (nwCornerY + distY) > stronghold.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
+							structures.remove(type);
 						}
 					} else if (type.equals(Type.VILLAGE)) {
 						List<WorldIcon> village = StructureSearcher.findVillage(
@@ -218,6 +227,7 @@ public class StructureSearcher {
 								coords);
 						if (village.size() >= 1 && (nwCornerX + distX) > village.get(0).getCoordinates().getX() && (nwCornerY + distY) > village.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);;
+							structures.remove(type);
 						}
 					} else if (type.equals(Type.PILLAGER_OUTPOST)) {
 						List<WorldIcon> pillagerOutpost = StructureSearcher.findPillagerOutpost(
@@ -225,6 +235,7 @@ public class StructureSearcher {
 								coords);
 						if (pillagerOutpost.size() >= 1 && (nwCornerX + distX) > pillagerOutpost.get(0).getCoordinates().getX() && (nwCornerY + distY) > pillagerOutpost.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
+							structures.remove(type);
 						}
 					} else if (type.equals(Type.DESERT_TEMPLE)) {
 						List<WorldIcon> deserttemple = StructureSearcher.findDesertTemple(
@@ -232,6 +243,7 @@ public class StructureSearcher {
 								coords);
 						if (deserttemple.size() >= 1 && (nwCornerX + distX) > deserttemple.get(0).getCoordinates().getX() && (nwCornerY + distY) > deserttemple.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
+							structures.remove(type);
 						}
 					} else if (type.equals(Type.JUNGLE_TEMPLE)) {
 						List<WorldIcon> jungleTemple = StructureSearcher.findJungleTemple(
@@ -239,6 +251,7 @@ public class StructureSearcher {
 								coords);
 						if (jungleTemple.size() >= 1 && (nwCornerX + distX) > jungleTemple.get(0).getCoordinates().getX() && (nwCornerY + distY) > jungleTemple.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
+							structures.remove(type);
 						}
 					} else if (type.equals(Type.WITCH_HUT)) {
 						List<WorldIcon> witchhut = StructureSearcher.findWitchHut(
@@ -246,6 +259,7 @@ public class StructureSearcher {
 								coords);
 						if (witchhut.size() >= 1 && (nwCornerX + distX) > witchhut.get(0).getCoordinates().getX() && (nwCornerY + distY) > witchhut.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
+							structures.remove(type);
 						}
 					} else if (type.equals(Type.IGLOO)) {
 						List<WorldIcon> igloo = StructureSearcher.findIgloo(
@@ -253,6 +267,7 @@ public class StructureSearcher {
 								coords);
 						if (igloo.size() >= 1 && (nwCornerX + distX) > igloo.get(0).getCoordinates().getX() && (nwCornerY + distY) > igloo.get(0).getCoordinates().getY()) {
 							foundStructures.add(type);
+							structures.remove(type);
 						}
 					}
 				}

--- a/src/main/java/sassa/main/StructureSearcher.java
+++ b/src/main/java/sassa/main/StructureSearcher.java
@@ -25,7 +25,6 @@ public class StructureSearcher {
 		List<WorldIcon> villageFeatures = findVillageFeatures(world, coords);
 		List<WorldIcon> pillager_outpost = new ArrayList<WorldIcon>();
 		for (WorldIcon feature : villageFeatures) {
-            System.out.println("Found feature: " + feature.getName() + " - " + feature.getCoordinates());
 			if (feature.getName().toUpperCase().equals("PILLAGER OUTPOST")) {
 				pillager_outpost.add(feature);
 			}

--- a/src/main/java/sassa/main/StructureSearcher.java
+++ b/src/main/java/sassa/main/StructureSearcher.java
@@ -148,109 +148,118 @@ public class StructureSearcher {
 	}
 
 	public static List<Type> hasStructures(Set<Type> structures, World world, long nwCornerX, long nwCornerY, int distX, int distY) {
-		CoordinatesInWorld coords = coords(nwCornerX, nwCornerY);
-        List<Type> foundStructures = new ArrayList();;
-		for (Type type : structures) {
-			if (type.equals(Type.MINESHAFT)) {
-				List<WorldIcon> mineshafts = StructureSearcher.findMineshafts(
-						world,
-						coords);
-				if (mineshafts.size() >= 1 && (nwCornerX + distX) > mineshafts.get(0).getCoordinates().getX() && (nwCornerY + distY) > mineshafts.get(0).getCoordinates().getY()) {
-					foundStructures.add(type);
+        List<Type> foundStructures = new ArrayList();
+        int multiplierX = 0;
+        int multiplierY = 0;
+		while ((nwCornerX + (multiplierX * 512)) < (nwCornerX + distX)) {
+			while ((nwCornerY + (multiplierY * 512)) < (nwCornerY + distY)) {
+				CoordinatesInWorld coords = coords(nwCornerX + (multiplierX * 512), nwCornerY + (multiplierY * 512));
+				System.out.println("Searching coords: " + coords);
+				for (Type type : structures) {
+					if (type.equals(Type.MINESHAFT)) {
+						List<WorldIcon> mineshafts = StructureSearcher.findMineshafts(
+								world,
+								coords);
+						if (mineshafts.size() >= 1 && (nwCornerX + distX) > mineshafts.get(0).getCoordinates().getX() && (nwCornerY + distY) > mineshafts.get(0).getCoordinates().getY()) {
+							foundStructures.add(type);
+						}
+					} else if (type.equals(Type.OCEAN_RUINS)) {
+						List<WorldIcon> ocean_ruins = StructureSearcher.findOceanRuins(
+								world,
+								coords);
+						if (ocean_ruins.size() >= 1 && (nwCornerX + distX) > ocean_ruins.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_ruins.get(0).getCoordinates().getY()) {
+							foundStructures.add(type);
+						}
+					} else if (type.equals(Type.OCEAN_FEATURES)) {
+						List<WorldIcon> ocean_features = StructureSearcher.findOceanFeatures(
+								world,
+								coords);
+						if (ocean_features.size() >= 1 && (nwCornerX + distX) > ocean_features.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_features.get(0).getCoordinates().getY()) {
+							foundStructures.add(type);
+						}
+					} else if (type.equals(Type.OCEAN_MONUMENT)) {
+						List<WorldIcon> ocean_monuments = StructureSearcher.findOceanMounments(
+								world,
+								coords);
+						if (ocean_monuments.size() >= 1 && (nwCornerX + distX) > ocean_monuments.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_monuments.get(0).getCoordinates().getY()) {
+							foundStructures.add(type);
+						}
+					} else if (type.equals(Type.SHIPWRECK)) {
+						List<WorldIcon> shipwreck = StructureSearcher.findShipwreck(
+								world,
+								coords);
+						if (shipwreck.size() >= 1 && (nwCornerX + distX) > shipwreck.get(0).getCoordinates().getX() && (nwCornerY + distY) > shipwreck.get(0).getCoordinates().getY()) {
+							foundStructures.add(type);
+						}
+					} else if (type.equals(Type.BURIED_TREASURE)) {
+						List<WorldIcon> buriedTreasure = StructureSearcher.findBuriedTreasure(
+								world,
+								coords);
+						if (buriedTreasure.size() >= 1 && (nwCornerX + distX) > buriedTreasure.get(0).getCoordinates().getX() && (nwCornerY + distY) > buriedTreasure.get(0).getCoordinates().getY()) {
+							foundStructures.add(type);
+						}
+					} else if (type.equals(Type.MANSION)) {
+						List<WorldIcon> mansion = StructureSearcher.findMansion(
+								world,
+								coords);
+						if (mansion.size() >= 1 && (nwCornerX + distX) > mansion.get(0).getCoordinates().getX() && (nwCornerY + distY) > mansion.get(0).getCoordinates().getY()) {
+							foundStructures.add(type);
+						}
+					} else if (type.equals(Type.STRONGHOLD)) {
+						List<WorldIcon> stronghold = StructureSearcher.findStronghold(
+								world,
+								coords);
+						if (stronghold.size() >= 1 && (nwCornerX + distX) > stronghold.get(0).getCoordinates().getX() && (nwCornerY + distY) > stronghold.get(0).getCoordinates().getY()) {
+							foundStructures.add(type);
+						}
+					} else if (type.equals(Type.VILLAGE)) {
+						List<WorldIcon> village = StructureSearcher.findVillage(
+								world,
+								coords);
+						if (village.size() >= 1 && (nwCornerX + distX) > village.get(0).getCoordinates().getX() && (nwCornerY + distY) > village.get(0).getCoordinates().getY()) {
+							foundStructures.add(type);;
+						}
+					} else if (type.equals(Type.PILLAGER_OUTPOST)) {
+						List<WorldIcon> pillagerOutpost = StructureSearcher.findPillagerOutpost(
+								world,
+								coords);
+						if (pillagerOutpost.size() >= 1 && (nwCornerX + distX) > pillagerOutpost.get(0).getCoordinates().getX() && (nwCornerY + distY) > pillagerOutpost.get(0).getCoordinates().getY()) {
+							foundStructures.add(type);
+						}
+					} else if (type.equals(Type.DESERT_TEMPLE)) {
+						List<WorldIcon> deserttemple = StructureSearcher.findDesertTemple(
+								world,
+								coords);
+						if (deserttemple.size() >= 1 && (nwCornerX + distX) > deserttemple.get(0).getCoordinates().getX() && (nwCornerY + distY) > deserttemple.get(0).getCoordinates().getY()) {
+							foundStructures.add(type);
+						}
+					} else if (type.equals(Type.JUNGLE_TEMPLE)) {
+						List<WorldIcon> jungleTemple = StructureSearcher.findJungleTemple(
+								world,
+								coords);
+						if (jungleTemple.size() >= 1 && (nwCornerX + distX) > jungleTemple.get(0).getCoordinates().getX() && (nwCornerY + distY) > jungleTemple.get(0).getCoordinates().getY()) {
+							foundStructures.add(type);
+						}
+					} else if (type.equals(Type.WITCH_HUT)) {
+						List<WorldIcon> witchhut = StructureSearcher.findWitchHut(
+								world,
+								coords);
+						if (witchhut.size() >= 1 && (nwCornerX + distX) > witchhut.get(0).getCoordinates().getX() && (nwCornerY + distY) > witchhut.get(0).getCoordinates().getY()) {
+							foundStructures.add(type);
+						}
+					} else if (type.equals(Type.IGLOO)) {
+						List<WorldIcon> igloo = StructureSearcher.findIgloo(
+								world,
+								coords);
+						if (igloo.size() >= 1 && (nwCornerX + distX) > igloo.get(0).getCoordinates().getX() && (nwCornerY + distY) > igloo.get(0).getCoordinates().getY()) {
+							foundStructures.add(type);
+						}
+					}
 				}
-			} else if (type.equals(Type.OCEAN_RUINS)) {
-				List<WorldIcon> ocean_ruins = StructureSearcher.findOceanRuins(
-						world,
-						coords);
-				if (ocean_ruins.size() >= 1 && (nwCornerX + distX) > ocean_ruins.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_ruins.get(0).getCoordinates().getY()) {
-					foundStructures.add(type);
-				}
-			} else if (type.equals(Type.OCEAN_FEATURES)) {
-				List<WorldIcon> ocean_features = StructureSearcher.findOceanFeatures(
-						world,
-						coords);
-				if (ocean_features.size() >= 1 && (nwCornerX + distX) > ocean_features.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_features.get(0).getCoordinates().getY()) {
-					foundStructures.add(type);
-				}
-			} else if (type.equals(Type.OCEAN_MONUMENT)) {
-				List<WorldIcon> ocean_monuments = StructureSearcher.findOceanMounments(
-						world,
-						coords);
-				if (ocean_monuments.size() >= 1 && (nwCornerX + distX) > ocean_monuments.get(0).getCoordinates().getX() && (nwCornerY + distY) > ocean_monuments.get(0).getCoordinates().getY()) {
-					foundStructures.add(type);
-				}
-			} else if (type.equals(Type.SHIPWRECK)) {
-				List<WorldIcon> shipwreck = StructureSearcher.findShipwreck(
-						world,
-						coords);
-				if (shipwreck.size() >= 1 && (nwCornerX + distX) > shipwreck.get(0).getCoordinates().getX() && (nwCornerY + distY) > shipwreck.get(0).getCoordinates().getY()) {
-					foundStructures.add(type);
-				}
-			} else if (type.equals(Type.BURIED_TREASURE)) {
-				List<WorldIcon> buriedTreasure = StructureSearcher.findBuriedTreasure(
-						world,
-						coords);
-				if (buriedTreasure.size() >= 1 && (nwCornerX + distX) > buriedTreasure.get(0).getCoordinates().getX() && (nwCornerY + distY) > buriedTreasure.get(0).getCoordinates().getY()) {
-					foundStructures.add(type);
-				}
-			} else if (type.equals(Type.MANSION)) {
-				List<WorldIcon> mansion = StructureSearcher.findMansion(
-						world,
-						coords);
-				if (mansion.size() >= 1 && (nwCornerX + distX) > mansion.get(0).getCoordinates().getX() && (nwCornerY + distY) > mansion.get(0).getCoordinates().getY()) {
-					foundStructures.add(type);
-				}
-
-			} else if (type.equals(Type.STRONGHOLD)) {
-				List<WorldIcon> stronghold = StructureSearcher.findStronghold(
-						world,
-						coords);
-				if (stronghold.size() >= 1 && (nwCornerX + distX) > stronghold.get(0).getCoordinates().getX() && (nwCornerY + distY) > stronghold.get(0).getCoordinates().getY()) {
-					foundStructures.add(type);
-				}
-			} else if (type.equals(Type.VILLAGE)) {
-				List<WorldIcon> village = StructureSearcher.findVillage(
-						world,
-						coords);
-				if (village.size() >= 1 && (nwCornerX + distX) > village.get(0).getCoordinates().getX() && (nwCornerY + distY) > village.get(0).getCoordinates().getY()) {
-					foundStructures.add(type);;
-				}
-			} else if (type.equals(Type.PILLAGER_OUTPOST)) {
-				List<WorldIcon> pillagerOutpost = StructureSearcher.findPillagerOutpost(
-						world,
-						coords);
-				if (pillagerOutpost.size() >= 1 && (nwCornerX + distX) > pillagerOutpost.get(0).getCoordinates().getX() && (nwCornerY + distY) > pillagerOutpost.get(0).getCoordinates().getY()) {
-					foundStructures.add(type);
-				}
-			} else if (type.equals(Type.DESERT_TEMPLE)) {
-				List<WorldIcon> deserttemple = StructureSearcher.findDesertTemple(
-						world,
-						coords);
-				if (deserttemple.size() >= 1 && (nwCornerX + distX) > deserttemple.get(0).getCoordinates().getX() && (nwCornerY + distY) > deserttemple.get(0).getCoordinates().getY()) {
-					foundStructures.add(type);
-				}
-			} else if (type.equals(Type.JUNGLE_TEMPLE)) {
-				List<WorldIcon> jungleTemple = StructureSearcher.findJungleTemple(
-						world,
-						coords);
-				if (jungleTemple.size() >= 1 && (nwCornerX + distX) > jungleTemple.get(0).getCoordinates().getX() && (nwCornerY + distY) > jungleTemple.get(0).getCoordinates().getY()) {
-					foundStructures.add(type);
-				}
-			} else if (type.equals(Type.WITCH_HUT)) {
-				List<WorldIcon> witchhut = StructureSearcher.findWitchHut(
-						world,
-						coords);
-				if (witchhut.size() >= 1 && (nwCornerX + distX) > witchhut.get(0).getCoordinates().getX() && (nwCornerY + distY) > witchhut.get(0).getCoordinates().getY()) {
-					foundStructures.add(type);
-				}
-			} else if (type.equals(Type.IGLOO)) {
-				List<WorldIcon> igloo = StructureSearcher.findIgloo(
-						world,
-						coords);
-				if (igloo.size() >= 1 && (nwCornerX + distX) > igloo.get(0).getCoordinates().getX() && (nwCornerY + distY) > igloo.get(0).getCoordinates().getY()) {
-					foundStructures.add(type);
-				}
+				multiplierY++;
 			}
+			multiplierY=0;
+			multiplierX++;
 		}
 
 		return foundStructures;


### PR DESCRIPTION
Currently the program only searches a 512x512 area for structures from the north west corner.
![image](https://user-images.githubusercontent.com/7288322/83307405-c0947d00-a258-11ea-809c-3cbe901df856.png)


This PR fixes that by searching 512x512 areas step by step until the full area has been searched.
![image](https://user-images.githubusercontent.com/7288322/83307074-ebca9c80-a257-11ea-8b7f-5ebe6b9b9eb2.png)

refer this comment here for more details:
https://github.com/Zodsmar/SeedSearcherStandaloneTool/pull/31#issuecomment-636191904