### PR TITLE
Remove unnecessary space after shadow seed

### DIFF
--- a/src/main/java/sassa/searcher/SearchingThread.java
+++ b/src/main/java/sassa/searcher/SearchingThread.java
@@ -124,7 +124,7 @@ public class SearchingThread extends Thread implements Runnable{
                         && bi.size() == 0 && bo.size() == 0 //
                         && ci.size() == 0 && co.size() == 0 && fxmlController.running == true) {
                     if(Singleton.getInstance().getShadowMode().isSelected()){
-                        util.console(String.valueOf(randomSeed) + " (Shadow: " + WorldSeed.getShadowSeed(randomSeed) + " )");
+                        util.console(String.valueOf(randomSeed) + " (Shadow: " + WorldSeed.getShadowSeed(randomSeed) + ")");
                     } else {
                         util.console(String.valueOf(randomSeed));
                     }


### PR DESCRIPTION
I just kept on copying the space of the shadow seed on accident, which got annoying, since a space is 'hard to see'.
The space there is also unnecessary, so having it there doesn't make sense. Typing this took more time than actually making this pull request.  
I have not tested this code because I love living on the edge. But with my expertise I am quite certain it works as intended without testing.  
I hope this enormous contribution will be appreciated.