### PR TITLE
Add /.classpath and /*.project to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /target/
 .vscode
 .settings
+/.classpath
+/*.project
 
 *.class
 


### PR DESCRIPTION
Prevents at least Atom editor from repeatedly suggesting these files as 
unstaged changes. Relevant: https://stackoverflow.com/a/49063303, in 
which the question also suggests that these should be not be committed 
and should be ignored by git. This makes it explicitly the case. Seems 
to work.

Hope this helps :)