### PR TITLE
 Add two separate batch files - build and run for easier testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /target/
 .vscode
 .settings
+/.classpath
+/*.project
 
 *.class
 

--- a/gradle-sassa-build-only.bat
+++ b/gradle-sassa-build-only.bat
@@ -1,0 +1,1 @@
+gradle build

--- a/gradle-sassa-run-only.bat
+++ b/gradle-sassa-run-only.bat
@@ -1,0 +1,1 @@
+gradle run


### PR DESCRIPTION
Not strictly necessary but makes workflow a bit easier by allowing 
double click to build or run (on Windows). On top of #87. The file names 
of course don't have to be exactly this but I thought it was the most 
clear. Any changes to the exact titles are of course welcome.